### PR TITLE
Site URL was changed to lynxscans.com

### DIFF
--- a/lua/modules/SecretScans.lua
+++ b/lua/modules/SecretScans.lua
@@ -45,7 +45,7 @@ function Init()
 	local m = NewWebsiteModule()
 	m.ID                       = '141a7dc7c72f4efdb311f689f16b1c71'
 	m.Name                     = 'SecretScans'
-	m.RootURL                  = 'https://secretscans.co'
+	m.RootURL                  = 'https://lynxscans.com'
 	m.Category                 = 'English-Scanlation'
 	m.OnGetInfo                = 'GetInfo'
 	m.OnGetDirectoryPageNumber = 'GetDirectoryPageNumber'


### PR DESCRIPTION
Site URL was changed from https://secretscans.co to https://lynxscans.com
I didn't change the module name to avoid any problem for previously added downloads
Unless there is a policy to always use the new name I think just updating the URL, might be a better option than renaming the module.
This change was tested and no problem with download was found.