### PR TITLE
GroupLe: Excluded invalid chapter links

### DIFF
--- a/lua/templates/GroupLe.lua
+++ b/lua/templates/GroupLe.lua
@@ -86,7 +86,7 @@ function _M.GetInfo()
 	MANGAINFO.Status    = MangaInfoStatusIfPos(x.XPathString('//div[@class="subject-meta"]'), 'выпуск продолжается', 'выпуск завершён')
 	MANGAINFO.Summary   = x.XPathString('(//div[@class="manga-description"])[1]')
 
-	x.XPathHREFAll('//table[@class="table table-hover"]//a', MANGAINFO.ChapterLinks, MANGAINFO.ChapterNames)
+	x.XPathHREFAll('//table[@class="table table-hover"]//a[not(contains(@href, "/internal/"))]', MANGAINFO.ChapterLinks, MANGAINFO.ChapterNames)
 	MANGAINFO.ChapterLinks.Reverse(); MANGAINFO.ChapterNames.Reverse()
 
 	HTTP.Reset()

--- a/lua/templates/GroupLe.lua
+++ b/lua/templates/GroupLe.lua
@@ -86,7 +86,7 @@ function _M.GetInfo()
 	MANGAINFO.Status    = MangaInfoStatusIfPos(x.XPathString('//div[@class="subject-meta"]'), 'выпуск продолжается', 'выпуск завершён')
 	MANGAINFO.Summary   = x.XPathString('(//div[@class="manga-description"])[1]')
 
-	x.XPathHREFAll('//table[@class="table table-hover"]//a[not(contains(@href, "/internal/"))]', MANGAINFO.ChapterLinks, MANGAINFO.ChapterNames)
+	x.XPathHREFAll('//table[@class="table table-hover"]//a[not(contains(@href, "/internal/")) and not(contains(@class, "btn"))]', MANGAINFO.ChapterLinks, MANGAINFO.ChapterNames)
 	MANGAINFO.ChapterLinks.Reverse(); MANGAINFO.ChapterNames.Reverse()
 
 	HTTP.Reset()


### PR DESCRIPTION
This MR updates the XPath selector used for chapter link extraction to exclude non-chapter links such as internal modal buttons (e.g., “upload cover” / “Загрузить обложку” links).

[Example page](https://a.zazaza.me/gatiakuta)

