### PR TITLE
Fixed: MangaGo Module

### DIFF
--- a/lua/modules/MangaGo.lua
+++ b/lua/modules/MangaGo.lua
@@ -316,12 +316,3 @@ function DownloadImage()
 
 	return true
 end
-
--- Search for manga on the website
-function GetSearchNameAndLink()
-    local u = MODULE.RootURL .. '/r/l_search/?name=' .. HTTP.URLEncode(SEARCHNAME)
-    if not HTTP.GET(u) then return net_problem end
-
-    CreateTXQuery(HTTP.Document).XPathHREFAll('//span[@class="title"]/a', LINKS, NAMES)
-    return no_error
-end

--- a/lua/modules/MangaGo.lua
+++ b/lua/modules/MangaGo.lua
@@ -322,9 +322,6 @@ function GetSearchNameAndLink()
     local u = MODULE.RootURL .. '/r/l_search/?name=' .. HTTP.URLEncode(SEARCHNAME)
     if not HTTP.GET(u) then return net_problem end
 
-    -- CETTE LIGNE SAUVEGARDE LA PAGE POUR QU'ON PUISSE L'ANALYSER :
-    HTTP.Document.SaveToFile("C:\\mangago_test.html")
-
     CreateTXQuery(HTTP.Document).XPathHREFAll('//span[@class="title"]/a', LINKS, NAMES)
     return no_error
 end


### PR DESCRIPTION
Bypassed 20k entry limit: Implemented a multi-genre looping logic to iterate through all site categories, expanding the accessible database from 20,000 to over 100,000+ titles.
Updated Pagination & Sorting: Integrated update_date as the default sorting parameter to ensure new releases are captured during the first pages of the scan.