### PR TITLE
Mangataro template update

### DIFF
--- a/lua/templates/MangaTaro.lua
+++ b/lua/templates/MangaTaro.lua
@@ -68,20 +68,33 @@ function _M.GetInfo()
 		utc.year, utc.month, utc.day, utc.hour
 	)
 
-	local mid = x.XPathString('//body/@data-manga-id')
-	local timestamp = os.time()
-	local token = md5_hex(timestamp .. 'mng_ch_' .. formatted):sub(1, 16)
+	local mid   = x.XPathString('//body/@data-manga-id')
+	local limit  = 500
+	local offset = 0
 
-	if not HTTP.GET(MODULE.RootURL .. '/auth/manga-chapters?manga_id=' .. mid .. '&offset=0&limit=9999&order=ASC&_t=' .. token .. '&_ts=' .. timestamp) then return net_problem end
+	while true do
+		-- Regenerate token per request; timestamp must be fresh each time
+		local timestamp = os.time()
+		local token = md5_hex(timestamp .. 'mng_ch_' .. formatted):sub(1, 16)
 
-	for v in CreateTXQuery(HTTP.Document).XPath('json(*).chapters()').Get() do
-		local chapter = v.GetProperty('chapter').ToString()
-		local title   = v.GetProperty('title').ToString()
+		if not HTTP.GET(MODULE.RootURL .. '/auth/manga-chapters?manga_id=' .. mid ..
+			'&offset=' .. offset .. '&limit=' .. limit ..
+			'&order=ASC&_t=' .. token .. '&_ts=' .. timestamp) then return net_problem end
 
-		title = (title ~= 'N/A' and title ~= '—' and title ~= '') and (' - ' .. title) or ''
+		local count = 0
+		for v in CreateTXQuery(HTTP.Document).XPath('json(*).chapters()').Get() do
+			local chapter = v.GetProperty('chapter').ToString()
+			local title   = v.GetProperty('title').ToString()
 
-		MANGAINFO.ChapterLinks.Add(v.GetProperty('url').ToString())
-		MANGAINFO.ChapterNames.Add('Chapter ' .. chapter .. title)
+			title = (title ~= 'N/A' and title ~= '—' and title ~= '') and (' - ' .. title) or ''
+
+			MANGAINFO.ChapterLinks.Add(v.GetProperty('url').ToString())
+			MANGAINFO.ChapterNames.Add('Chapter ' .. chapter .. title)
+			count = count + 1
+		end
+
+		if count < limit then break end
+		offset = offset + limit
 	end
 
 	return no_error

--- a/lua/templates/MangaTaro.lua
+++ b/lua/templates/MangaTaro.lua
@@ -68,8 +68,8 @@ function _M.GetInfo()
 		utc.year, utc.month, utc.day, utc.hour
 	)
 
-	local mid   = x.XPathString('//body/@data-manga-id')
-	local limit  = 500
+	local mid = x.XPathString('//body/@data-manga-id')
+	local limit = 500
 	local offset = 0
 
 	while true do


### PR DESCRIPTION
Updating grab request. Current process limits to 500 total chapters allowed for server pull cap. Testing with https://mangataro.org/manga/against-the-gods  --> total chapters 753

Updated the single 9999 call to a limit of 500 with a while true so that it can grab all chapters. This appears to be working as intended I now see full 753 chapters in fmd

Had to move the timestamp and token generation to the loop so it can create the md5 token on each request so it validates timestamp properly

Used Claude AI to help create and validate code update