### PR TITLE
Update cbz/zip compression to be faster

### DIFF
--- a/baseunits/uPacker.pas
+++ b/baseunits/uPacker.pas
@@ -87,24 +87,6 @@ begin
   end;
 
   Result := FileExists(FSavedFileName);
-  if Result then
-  begin
-    with TUnZipper.Create do
-    begin
-      try
-         FileName := FSavedFileName;
-         Examine;
-         Result := FileList.Count = Entries.Count;
-
-         if not Result then
-         begin
-           Logger.SendWarning('Some files failed to be compressed!');
-         end;
-      finally
-        Free;
-      end;
-    end;
-  end;
 end;
 
 Function MaybeQuoteIfNotQuoted(Const S : TProcessString) : TProcessString;
@@ -334,7 +316,7 @@ begin
 
   packResult:=True;
   case Format of
-    pfZIP, pfCBZ: packResult:=Do7Zip;
+    pfZIP, pfCBZ: packResult:=DoZipCbz;
     pfPDF: DoPdf;
     pfEPUB: DoEpub;
   end;
@@ -347,12 +329,9 @@ begin
   Result := FileExists(FSavedFileName);
   if Result then
   begin
-    if not (Format in [pfZIP, pfCBZ]) then // let 7za delete the files
+    for i := 0 to FFileList.Count - 1 do
     begin
-      for i := 0 to FFileList.Count - 1 do
-      begin
-        DeleteFile(FFileList[i]);
-      end;
+      DeleteFile(FFileList[i]);
     end;
 
     if IsDirectoryEmpty(Path) then


### PR DESCRIPTION
CBZ compression took time and sometimes would stall. 
I wanted to try and resolve that. 
TZipper already stops and throws an exception if it can't add a file, so if packing failed, the code wouldn't reach the verification.

Use DoZipCbz instead of relying on 7za.exe
Previously, packing CBZ needed to hand the job off to 7za.exe and wait for it to finish 
DoZipCbz is already a method that can do the job and not use resources on 7za